### PR TITLE
Fluid 2797: The prev next link moves as user clicks previous

### DIFF
--- a/demos/pager/index.html
+++ b/demos/pager/index.html
@@ -59,7 +59,8 @@
         <div class="flc-pager-top">
             <ul class="demo-pager-bar fl-force-left fl-focus">
                 <li class="flc-pager-previous demo-pager-previous"><a href="#" title="Previous Page">&lt; Previous</a></li>
-                <li>
+                <li class="flc-pager-li-container"> <!-- FLUID-2797
+The prev/next link moves as user clicks previous, Next Button Click Fix -->
                     <ul class="flc-pager-links demo-pager-links">
                         <li class="flc-pager-pageLink demo-pager-pageLink-default"><a href="#">1</a></li>
                         <li class="flc-pager-pageLink-skip demo-pager-pageLink-skip ">...</li>
@@ -105,7 +106,8 @@
         <div class="flc-pager-bottom">
             <ul class="demo-pager-bar fl-force-left fl-focus">
                 <li class="flc-pager-previous demo-pager-previous"><a href="#">&lt; Previous</a></li>
-                <li>
+                               <li class="flc-pager-li-container"> <!-- FLUID-2797
+The prev/next link moves as user clicks previous, Next Button Click Fix -->
                     <ul class="flc-pager-links demo-pager-links">
                         <li class="flc-pager-pageLink demo-pager-pageLink-default"><a href="#">1</a></li>
                         <li class="flc-pager-pageLink-skip demo-pager-pageLink-skip">...</li>

--- a/examples/components/pager/annotateSortedColumn/index.html
+++ b/examples/components/pager/annotateSortedColumn/index.html
@@ -52,7 +52,8 @@
         <div class="flc-pager-top">
             <ul class="example-pager-bar fl-force-left fl-focus">
                 <li class="flc-pager-previous example-pager-previous"><a href="#" title="Previous Page">&lt; Previous</a></li>
-                <li>
+                               <li class="flc-pager-li-container"> <!-- FLUID-2797
+The prev/next link moves as user clicks previous, Next Button Click Fix -->
                     <ul class="flc-pager-links example-pager-links">
                         <li class="flc-pager-pageLink example-pager-pageLink-default"><a href="#">1</a></li>
                         <li class="flc-pager-pageLink-skip example-pager-pageLink-skip ">...</li>
@@ -98,7 +99,8 @@
         <div class="flc-pager-bottom">
             <ul class="example-pager-bar fl-force-left fl-focus">
                 <li class="flc-pager-previous example-pager-previous"><a href="#">&lt; Previous</a></li>
-                <li>
+                                <li class="flc-pager-li-container"> <!-- FLUID-2797
+The prev/next link moves as user clicks previous, Next Button Click Fix -->
                     <ul class="flc-pager-links example-pager-links">
                         <li class="flc-pager-pageLink example-pager-pageLink-default"><a href="#">1</a></li>
                         <li class="flc-pager-pageLink-skip example-pager-pageLink-skip">...</li>

--- a/examples/components/pager/initialPageIndex/index.html
+++ b/examples/components/pager/initialPageIndex/index.html
@@ -52,7 +52,8 @@
         <div class="flc-pager-top">
             <ul class="example-pager-bar fl-force-left fl-focus">
                 <li class="flc-pager-previous example-pager-previous"><a href="#" title="Previous Page">&lt; Previous</a></li>
-                <li>
+                               <li class="flc-pager-li-container"> <!-- FLUID-2797
+The prev/next link moves as user clicks previous, Next Button Click Fix -->
                     <ul class="flc-pager-links example-pager-links">
                         <li class="flc-pager-pageLink example-pager-pageLink-default"><a href="#">1</a></li>
                         <li class="flc-pager-pageLink-skip example-pager-pageLink-skip ">...</li>
@@ -98,7 +99,8 @@
         <div class="flc-pager-bottom">
             <ul class="example-pager-bar fl-force-left fl-focus">
                 <li class="flc-pager-previous example-pager-previous"><a href="#">&lt; Previous</a></li>
-                <li>
+                                <li class="flc-pager-li-container"> <!-- FLUID-2797
+The prev/next link moves as user clicks previous, Next Button Click Fix -->
                     <ul class="flc-pager-links example-pager-links">
                         <li class="flc-pager-pageLink example-pager-pageLink-default"><a href="#">1</a></li>
                         <li class="flc-pager-pageLink-skip example-pager-pageLink-skip">...</li>

--- a/src/components/pager/css/Pager.css
+++ b/src/components/pager/css/Pager.css
@@ -53,6 +53,12 @@
     cursor:default;
 }
 
+/* Pager List Item Conatiner Width */ 
+
+.flc-pager-li-container {
+ width:550px !important; /* FLUID-2797 The prev/next link moves as user clicks previous, Next Button Click Fix */
+}
+
 
 /***********************************************************/
 /** THEMES - High Contrast **/
@@ -67,3 +73,5 @@
 }
 
 /* Pager UI */
+
+


### PR DESCRIPTION
Fluid 2797: The prev next link moves as user clicks previous, bug fixed
by making the List Item Container's width fixed.